### PR TITLE
Fix path joining for empty package paths

### DIFF
--- a/autoupgrade.go
+++ b/autoupgrade.go
@@ -106,6 +106,6 @@ func (u *UpgradeResult) NewBuildInfo() (*debug.BuildInfo, error) {
 // It combines the module path, package path, and version into the format
 // expected by go install.
 func fullPath(modulePath, packagePath, version string) string {
-	ret := path.Join(modulePath, packagePath+"@"+version)
+	ret := path.Join(modulePath, packagePath) + "@" + version
 	return ret
 }


### PR DESCRIPTION
# Description

Fixed an issue where the `fullPath` function was generating invalid module paths when the package path is empty, causing `go install` to fail.

## Current Behaviour
When attempting to upgrade a module with an empty package path (e.g., `dbut.dev` with package path `""`), the function generates an invalid path with a trailing slash:
```
dbut.dev/helpme/@latest
```

This results in the following error:
```
go: dbut.dev/helpme/@latest: argument must be a clean package path
exit status 1
```

## Expected Behavior
The function should generate a valid module path without a trailing slash when the package path is empty:
```
dbut.dev@latest
```